### PR TITLE
docs: add a link to chatgpt-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ For some Bubble Tea programs in production, see:
 * [brows](https://github.com/rubysolo/brows): a GitHub release browser
 * [Canard](https://github.com/mrusme/canard): an RSS client
 * [charm](https://github.com/charmbracelet/charm): the official Charm user account manager
+* [chatgpt-cli](https://github.com/j178/chatgpt): an elegant interactive cli for ChatGPT
 * [chezmoi](https://github.com/twpayne/chezmoi): securely manage your dotfiles across multiple machines
 * [chtop](https://github.com/chhetripradeep/chtop): monitor your ClickHouse node without leaving terminal
 * [circumflex](https://github.com/bensadeh/circumflex): read Hacker News in the terminal


### PR DESCRIPTION
Hi, 
I added a link to my chatgpt project in the Bubble Tea in the Wild section of the README.

This is how it looks:
![chatgpt-1 0](https://user-images.githubusercontent.com/10510431/229564407-e4c0b6bf-adfb-40f0-a63c-840dafbc1291.gif)